### PR TITLE
Wait until download data flushed to disk before loadFile invokes callback

### DIFF
--- a/lib/agent/AgentActions.js
+++ b/lib/agent/AgentActions.js
@@ -342,19 +342,21 @@ AgentActions.prototype.loadFile = function(bucket, keyBase, slot, file, cb) {
     shell.mkdir('-p', tmpPath);
   }
 
+  var error = null;
   var outStream = fs.createWriteStream(filename);
+  outStream.on('finish', function() { cb(error); });
   var done = false;
   var s3GetObject = { Bucket: bucket, Key: keyBase + '/' + file };
   log.info('Downloading [%j] to [%s]', s3GetObject, filename);
   this.s3.getObject(s3GetObject)
     .on('httpData', function(chunk) { outStream.write(chunk); })
-    .on('httpDone', function() { outStream.end(); if (!done) { done = true; cb(); } })
+    .on('httpDone', function() { if (!done) { done = true; outStream.end(); } })
     .on('error', function(err) {
-      outStream.end();
       if (!done) {
         done = true;
-        err.message = util.format('%s: %j', err.message, s3GetObject);
-        return cb(err);
+        error = err;
+        error.message = util.format('%s: %j', error.message, s3GetObject);
+        outStream.end();
       }
     })
     .send();
@@ -529,4 +531,3 @@ AgentActions.prototype.addListing = function(slot) {
 };
 
 module.exports = AgentActions;
-

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "superagent": "0.17.0"
   },
   "devDependencies": {
-    "salinity": "0.0.5",
+    "salinity": "0.0.8",
     "supertest": "0.10.0"
   }
 }


### PR DESCRIPTION
On faster machines, the subsequent tar expansion fails because not all data was flushed to disk yet. Explicitly wait for 'finish' callback on file write stream.

Jamie mentioned that he has seen this periodically, but a subsequent run succeeded. I couldn't get a deploy to work at all on a beefier machine.

This will only be for the new cluster with a new AMI.

@jh-bate @jebeck 